### PR TITLE
Set permissions on `start.sh` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apk --no-cache add \
 
 COPY ./src /app/src
 COPY ./docker/start.sh /start.sh
+RUN chmod +x /start.sh
 RUN mkdir /app/log
 
 COPY --from=build /app/env /app/env


### PR DESCRIPTION
Fixes #4 

The `docker-compose up` command failed because it could not execute `/start.sh` failing with the following error:

> ERROR: for web  Cannot start service web: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"/start.sh\": permission denied": unknown

GitHub has added the extra line-break at the end of the file.